### PR TITLE
WithoutMatcher

### DIFF
--- a/lib/sunspot_matchers/matchers.rb
+++ b/lib/sunspot_matchers/matchers.rb
@@ -143,8 +143,10 @@ module SunspotMatchers
 
     def get_matcher
       case @method
-        when :with, :without
+        when :with
           WithMatcher
+        when :without
+          WithoutMatcher
         when :keywords
           KeywordsMatcher
         when :boost
@@ -166,6 +168,16 @@ module SunspotMatchers
   class WithMatcher < BaseMatcher
     def search_method
       :with
+    end
+
+    def keys_to_compare
+      [:fq]
+    end
+  end
+
+  class WithoutMatcher < BaseMatcher
+    def search_method
+      :without
     end
 
     def keys_to_compare


### PR DESCRIPTION
Hi Joseph;

Specs for my project using a :without clause were returning a false positive whenever a :with clause existed on the same attribute. I'm not entirely sure why, because your test suite passes on :without, but this change seemed to fix it for my purposes. YMMV.

Thanks!

Scott
