### PR TITLE
Throws uninitialized constant exception when searching on multiple models

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sunspot_matchers (1.2.1.1)
+    sunspot_matchers (1.2.1.3)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/sunspot_matchers/sunspot_session_spy.rb
+++ b/lib/sunspot_matchers/sunspot_session_spy.rb
@@ -97,7 +97,7 @@ module SunspotMatchers
       if types.length == 1
         Sunspot::Setup.for(types.first)
       else
-        CompositeSetup.for(types)
+        Sunspot::CompositeSetup.for(types)
       end
     end
   end

--- a/spec/sunspot_matchers_spec.rb
+++ b/spec/sunspot_matchers_spec.rb
@@ -28,6 +28,13 @@ describe "Sunspot Matchers" do
   end
 
   describe "have_search_params" do
+    it "should allow you to specify your search on multiple models" do
+      Sunspot.search([Post, Blog]) do
+        keywords 'great pizza'
+      end
+      Sunspot.session.searches.first.should have_search_params(:keywords, 'great pizza')
+    end
+
     it "should allow you to specify your search" do
       Sunspot.search(Post) do
         keywords 'great pizza'


### PR DESCRIPTION
When searching on multiple models ( Sunspot.search([Post,Blog]) ... ) the following exception is thrown:
uninitialized constant SunspotMatchers::SunspotSessionSpy::CompositeSetup

This commit fixes this error and adds a spec that verifies the fix.
