### PR TITLE
Small improvements for have_searchable_field

### DIFF
--- a/lib/sunspot_matchers/matchers.rb
+++ b/lib/sunspot_matchers/matchers.rb
@@ -312,8 +312,8 @@ module SunspotMatchers
       @field = field
     end
 
-    def matches?(klass)
-      @klass = klass
+    def matches?(klass_or_object)
+      @klass = klass_or_object.class.name == 'Class' ? klass_or_object : klass_or_object.class
       @sunspot = Sunspot::Setup.for(@klass)
       (@sunspot.all_text_fields + @sunspot.fields).collect(&:name).uniq.include?(@field)
     end


### PR DESCRIPTION
I've done small improvements for have_searchable_field macher to give it a bit more flexibility.

List of changes:
- allow check if attribute fields are defined also
- allow use it directly on tested class without explicity define

Sample:

``` ruby
describe Post do
  it { should have_searchable_field(:body) }
end
```
