### PR TITLE
Adding description to have_searchable_field matcher

### DIFF
--- a/lib/sunspot_matchers/matchers.rb
+++ b/lib/sunspot_matchers/matchers.rb
@@ -330,6 +330,10 @@ module SunspotMatchers
       (@sunspot.all_text_fields + @sunspot.fields).collect(&:name).include?(@field)
     end
 
+    def description
+      "should have searchable field #{@field}"
+    end
+
     def failure_message_for_should
       "expected class: #{@klass} to have searchable field: #{@field}"
     end


### PR DESCRIPTION
Added a description for have_searchable_field matcher so it doesn't output a message saying you need a description. 
