### PR TITLE
Fix any_param to work with a time attribute

### DIFF
--- a/lib/sunspot_matchers/matchers.rb
+++ b/lib/sunspot_matchers/matchers.rb
@@ -350,6 +350,12 @@ module SunspotMatchers
   end
 end
 
+class AnyParam < String
+  def utc
+    Time.now.utc
+  end
+end
+
 def any_param
-  "ANY_PARAM"
+  AnyParam.new("ANY_PARAM")
 end

--- a/spec/sunspot_matchers_spec.rb
+++ b/spec/sunspot_matchers_spec.rb
@@ -204,6 +204,13 @@ describe "Sunspot Matchers" do
         Sunspot.session.should have_search_params(:with, :blog_id, any_param)
       end
 
+      it "should work with a time attribute and any_param match" do
+        Sunspot.search(Post) do
+          with :published_at, 'July 1st, 2009'
+        end
+        Sunspot.session.should have_search_params(:with, :published_at, any_param)
+      end
+
       it "should work with any_param negative match no with at all" do
         Sunspot.search(Post) do
           keywords 'great pizza'


### PR DESCRIPTION
When a TimeType is used, the 'ANY_PARAM' string will fail to parse (producing an 'invalid date' ArgumentError from [sunspot/type.rb:236](https://github.com/sunspot/sunspot/blob/master/sunspot/lib/sunspot/type.rb#L236)).

Pull request includes a failing spec for this case and a fix for the problem by allowing `any_param` to [respond to .utc](https://github.com/sunspot/sunspot/blob/master/sunspot/lib/sunspot/type.rb#L228) with the current time.
