### PR TITLE
Add Fulltext support to Test::Unit

### DIFF
--- a/lib/sunspot_matchers/test_helper.rb
+++ b/lib/sunspot_matchers/test_helper.rb
@@ -4,34 +4,34 @@ require File.expand_path('../matchers', __FILE__)
 require File.expand_path('../sunspot_session_spy', __FILE__)
 module SunspotMatchers
   class HaveSearchParamsForSession
-      include Test::Unit::Assertions
+    include Test::Unit::Assertions
 
-      def initialize(session, method, *args, &block)
-        @session = session
-        @method = method
-        @args = [*args, block].compact
-      end
-
-      def get_matcher
-        matcher_class = case @method
-          when :with
-            WithMatcher
-          when :without
-            WithoutMatcher
-          when :keywords
-            KeywordsMatcher
-          when :boost
-            BoostMatcher
-          when :facet
-            FacetMatcher
-          when :order_by
-            OrderByMatcher
-          when :paginate
-            PaginationMatcher
-        end
-        matcher_class.new(@session, @args)
-      end
+    def initialize(session, method, *args, &block)
+      @session = session
+      @method = method
+      @args = [*args, block].compact
     end
+
+    def get_matcher
+      matcher_class = case @method
+        when :with
+          WithMatcher
+        when :without
+          WithoutMatcher
+        when :keywords, :fulltext
+          KeywordsMatcher
+        when :boost
+          BoostMatcher
+        when :facet
+          FacetMatcher
+        when :order_by
+          OrderByMatcher
+        when :paginate
+          PaginationMatcher
+      end
+      matcher_class.new(@session, @args)
+    end
+  end
 
   
   class BeASearchForSession

--- a/test/sunspot_matchers_test.rb
+++ b/test/sunspot_matchers_test.rb
@@ -89,6 +89,13 @@ class SunspotMatchersTest < Test::Unit::TestCase
     assert_has_no_search_params Sunspot.session, :keywords, any_param
   end
 
+  def test_match_fulltext
+    Sunspot.search(Post) do
+      fulltext 'great pizza'
+    end
+    assert_has_search_params Sunspot.session, :fulltext, 'great pizza'
+  end
+
   def test_with_matcher_matches
     Sunspot.search(Post) do
       with :author_name, 'Mark Twain'


### PR DESCRIPTION
In the Rspec version, :fulltext and :keywords can be used
interchangeably in the tests. But the Test::Unit version only allowed
:keywords. Trying to use :fulltext resulted in an error.

This commit adds a test for :fulltext in the Test::Unit version,
implements :fulltext support and tweaks the indenting in the Test::Unit
file. The last one is only because Syntastic bugged me about it, though.
