### PR TITLE
Making Rspec 3 compliant, Fixing deprecation warning #16

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,32 @@
 PATH
   remote: .
   specs:
-    sunspot_matchers (2.1.0.0)
+    sunspot_matchers (2.1.0.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     builder (3.2.2)
-    diff-lcs (1.1.2)
+    diff-lcs (1.2.5)
     pr_geohash (1.0.0)
     rake (0.8.7)
     rsolr (1.0.9)
       builder (>= 2.1.2)
-    rspec (2.4.0)
-      rspec-core (~> 2.4.0)
-      rspec-expectations (~> 2.4.0)
-      rspec-mocks (~> 2.4.0)
-    rspec-core (2.4.0)
-    rspec-expectations (2.4.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.4.0)
+    rspec (3.0.0.beta2)
+      rspec-core (= 3.0.0.beta2)
+      rspec-expectations (= 3.0.0.beta2)
+      rspec-mocks (= 3.0.0.beta2)
+    rspec-core (3.0.0.beta2)
+      rspec-support (= 3.0.0.beta2)
+    rspec-expectations (3.0.0.beta2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (= 3.0.0.beta2)
+    rspec-its (1.0.1)
+      rspec-core (>= 2.99.0.beta1)
+      rspec-expectations (>= 2.99.0.beta1)
+    rspec-mocks (3.0.0.beta2)
+      rspec-support (= 3.0.0.beta2)
+    rspec-support (3.0.0.beta2)
     sunspot (2.1.0)
       pr_geohash (~> 1.0)
       rsolr (~> 1.0.7)
@@ -30,6 +37,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (>= 1.0.0)
   rake
-  rspec (~> 2.4.0)
+  rspec (~> 3.0.0.beta2)
+  rspec-its
   sunspot (~> 2.1.0)
   sunspot_matchers!

--- a/lib/sunspot_matchers/matchers.rb
+++ b/lib/sunspot_matchers/matchers.rb
@@ -135,11 +135,11 @@ module SunspotMatchers
       @matcher.match?
     end
 
-    def failure_message_for_should
+    def failure_message
       @matcher.missing_param_error_message
     end
 
-    def failure_message_for_should_not
+    def failure_message_when_negated
       @matcher.unexpected_match_error_message
     end
 
@@ -306,11 +306,11 @@ module SunspotMatchers
       search_tuple.first
     end
 
-    def failure_message_for_should
+    def failure_message
       "expected search class: #{search_types.join(' and ')} to match expected class: #{@expected_class}"
     end
 
-    def failure_message_for_should_not
+    def failure_message_when_negated
       "expected search class: #{search_types.join(' and ')} NOT to match expected class: #{@expected_class}"
     end
   end
@@ -335,12 +335,12 @@ module SunspotMatchers
       "should have searchable field #{@field}"
     end
 
-    def failure_message_for_should
+    def failure_message
       message = "expected class: #{@klass} to have searchable field: #{@field}"
       message << ", but Sunspot was not configured on #{@klass}" unless @sunspot
     end
 
-    def failure_message_for_should_not
+    def failure_message_when_negated
       "expected class: #{@klass} NOT to have searchable field: #{@field}"
     end
   end

--- a/spec/have_searchable_field_matcher_spec.rb
+++ b/spec/have_searchable_field_matcher_spec.rb
@@ -1,5 +1,6 @@
 require 'sunspot'
 require 'sunspot_matchers'
+require 'rspec/its'
 
 describe SunspotMatchers::HaveSearchableField do
   subject do
@@ -11,7 +12,7 @@ describe SunspotMatchers::HaveSearchableField do
   context "when a class has no searchable fields" do
     let(:klass) { NotALotGoingOn = Class.new }
 
-    its(:failure_message_for_should) { should =~ /Sunspot was not configured/ }
+    its(:failure_message) { should =~ /Sunspot was not configured/ }
   end
 
   context "when a class has an unexpected searchable field" do
@@ -20,6 +21,6 @@ describe SunspotMatchers::HaveSearchableField do
       Sunspot.setup(klass) { text :parachute }
     end
 
-    its(:failure_message_for_should) { should_not =~ /Sunspot was not configured/ }
+    its(:failure_message) { should_not =~ /Sunspot was not configured/ }
   end
 end

--- a/sunspot_matchers.gemspec
+++ b/sunspot_matchers.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_development_dependency "bundler", ">= 1.0.0"
-  s.add_development_dependency "rspec", "~> 2.4.0"
+  s.add_development_dependency "rspec", "~> 3.0.0.beta2"
+  s.add_development_dependency "rspec-its"
   s.add_development_dependency "sunspot", "~> 2.1.0"
   s.add_development_dependency "rake"
 


### PR DESCRIPTION
Making Rspec 3 compliant fixing the Deprecation warnings 

```
Deprecation Warnings:

--------------------------------------------------------------------------
SunspotMatchers::HaveSearchableField implements a legacy RSpec matcher
protocol. For the current protocol you should expose the failure messages
via the `failure_message` and `failure_message_when_negated` methods.
(Used from /Users/ankitgupta/Documents/projects/work/my-development/spec/models/article_spec.rb:18:in `block (2 levels) in <top (required)>')
--------------------------------------------------------------------------
--------------------------------------------------------------------------
SunspotMatchers::HaveSearchableField implements a legacy RSpec matcher
protocol. For the current protocol you should expose the failure messages
via the `failure_message` and `failure_message_when_negated` methods.
(Used from /Users/ankitgupta/Documents/projects/work/my-development/spec/models/article_spec.rb:19:in `block (2 levels) in <top (required)>')
--------------------------------------------------------------------------


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

2 deprecation warnings total

Randomized with seed 62963
```
