### PR TITLE
Add have_indexed_field matcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in sunspot_matchers.gemspec
 gemspec
+
+gem 'sunspot', :git => 'git://github.com/grossadamm/sunspot.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: git://github.com/grossadamm/sunspot.git
+  revision: f27dcf78859ac974a48eafab3e84271f092f0c8a
+  specs:
+    sunspot (2.1.1)
+      pr_geohash (~> 1.0)
+      rsolr (~> 1.0.7)
+
 PATH
   remote: .
   specs:
@@ -20,9 +28,6 @@ GEM
     rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.6)
-    sunspot (2.1.1)
-      pr_geohash (~> 1.0)
-      rsolr (~> 1.0.7)
 
 PLATFORMS
   ruby
@@ -31,5 +36,5 @@ DEPENDENCIES
   bundler (>= 1.0.0)
   rake
   rspec (~> 2.0)
-  sunspot (~> 2.1.1)
+  sunspot!
   sunspot_matchers!

--- a/README.markdown
+++ b/README.markdown
@@ -66,6 +66,29 @@ You can also use the shorthand syntax:
       it { should have_searchable_field(:name) }
     end
 
+## have_indexed_field
+
+If you want to verify that an index operation has been performed, you can use this matcher:
+
+`Sunspot.session.should have_indexed_field(Post, :name)`
+
+You can also use the shorthand syntax:
+
+    subject(:session) { Sunspot.session }
+    it { should have_indexed_field(Post, :name) }
+    
+You can also pass in a specific model, however this depends on your model having a `.id`:
+
+    before(:each) { @post = create(:post) }
+    subject(:session) { Sunspot.session }
+    it { should have_indexed_field(@post, :name) }
+
+You can even specify what the value should be using `.with("foo")`:
+
+    before(:each) { @post = create(:post, name: "foo") }
+    subject(:session) { Sunspot.session }
+    it { should have_indexed_field(@post, :name).with("foo") }
+
 ## have_search_params
 
 This is where the bulk of the functionality lies.  There are seven types of search matches you can perform: `keywords` or `fulltext`,

--- a/README.markdown
+++ b/README.markdown
@@ -66,28 +66,17 @@ You can also use the shorthand syntax:
       it { should have_searchable_field(:name) }
     end
 
-## have_indexed_field
+## have_been_indexed
 
 If you want to verify that an index operation has been performed, you can use this matcher:
 
-`Sunspot.session.should have_indexed_field(Post, :name)`
-
-You can also use the shorthand syntax:
-
-    subject(:session) { Sunspot.session }
-    it { should have_indexed_field(Post, :name) }
-    
-You can also pass in a specific model, however this depends on your model having a `.id`:
-
-    before(:each) { @post = create(:post) }
-    subject(:session) { Sunspot.session }
-    it { should have_indexed_field(@post, :name) }
-
-You can even specify what the value should be using `.with("foo")`:
-
-    before(:each) { @post = create(:post, name: "foo") }
-    subject(:session) { Sunspot.session }
-    it { should have_indexed_field(@post, :name).with("foo") }
+    subject(:post) { create(:post, foo: "bar") }
+    it { is_expected.to have_been_indexed }
+    it { is_expected.to have_been_indexed.with_field(:foo, "bar") }
+    it { is_expected.to have_been_indexed.with_field(:foo, any_param) }
+    it "indexes a Post" do
+      expect(Post).to have_been_indexed
+    end
 
 ## have_search_params
 

--- a/lib/sunspot_matchers/matchers.rb
+++ b/lib/sunspot_matchers/matchers.rb
@@ -349,77 +349,98 @@ module SunspotMatchers
     HaveSearchableField.new(field)
   end
 
-  class HaveIndexedField
-    def initialize(klass_or_object, field)
-      @klass = klass_or_object.class.name == 'Class' ? klass_or_object : klass_or_object.class
-      @object = klass_or_object.class.name != 'Class' ? klass_or_object : nil
-      @field = field
+  class HaveBeenIndexed
+    def initialize
     end
 
-    def matches?(session)
-      return false unless HaveSearchableField.new(@field).matches?(@klass)
-
-      sunspot = Sunspot::Setup.for(@klass)
-      sunspot_field = (sunspot.all_text_fields + sunspot.fields).find {|field| field.name == @field}
-
-      session.indexed.find do |document|
-        next unless matches_object?(document)
+    def matches?(klass_or_object)
+      @klass = klass_or_object.class.name == 'Class' ? klass_or_object : klass_or_object.class
+      @object = klass_or_object.class.name != 'Class' ? klass_or_object : nil
+      
+      Sunspot.session.indexed.find do |document|
+        next unless matches_class?(document, @klass)
+        next unless matches_object?(document, @object) if @object
         document.fields.find do |field|
-          return true if matches_field_name?(sunspot_field, field) && matches_target_value?(field)
+          return true if matches_field_name?(field) && matches_target_value?(field)
         end
       end 
+
       false
     end
 
     def description
-      message = "should have indexed field #{@field}" 
-      message << " with a value of #{@target_value}" if @target_value
-      message << " on #{@object.class.name} with id #{@object.id}" if @object
+      message = "should have indexed #{@klass}" 
+      message << " with id #{@object.id}" if @object
+      message << " with a field #{@field} of value #{@target_value}" if @target_value
     end
 
     def failure_message
-      message = "expected Sunspot session to have indexed field: #{@field}"
-      message << " with a value of #{@target_value}" if @target_value
-      message << " on #{@object.class.name} with id #{@object.id}" if @object
+      message = "expected Sunspot session to have indexed #{@klass}"
+      message << " with id #{@object.id}" if @object
+      message << " with a field #{@field} of value #{@target_value}" if @target_value
       message << ", but Sunspot did not"
     end
 
-    def failure_message_when_negated
-      message = "expected sunspot to NOT index #{@field}"
-      message << " with a value of #{@target_value}" if @target_value
-      message << " on #{@object.class.name} with id #{@object.id}" if @object
+    def negative_failure_message
+      message = "should have NOT indexed #{@klass}" 
+      message << " with id #{@object.id}" if @object
+      message << " with a field #{@field} of value #{@target_value}" if @target_value
     end
 
-    def with(value)
+    def failure_message_when_negated
+      negative_failure_message
+    end
+
+    def with_field(field, value)
+      @field = field
       @target_value = value
       self
     end
 
     private
-      def matches_object?(document)
-        return true unless @object
-
-        id_field = document.fields.find do |field|
+      def id_field(document)
+        document.fields.find do |field|
           field.attrs[:name] == :id
         end
+      end
+
+      def matches_object?(document, object)
+        return false unless object
+        id_field = id_field(document)
 
         return false unless id_field
 
-        id_field.value == "#{@object.class.name} #{@object.id}"
+        id_field.value == "#{object.class.name} #{object.id}"
+      end
+
+      def matches_class?(document, klass)
+        return false unless klass
+        id_field = id_field(document)
+
+        return false unless id_field
+
+        id_field.value.rpartition(' ').first == klass.to_s
       end
 
       def matches_target_value?(field)
         return true unless @target_value
+        return true if @target_value == any_param
         field.value == @target_value.to_s
       end
 
-      def matches_field_name?(sunspot_field, field)
+      def matches_field_name?(field)
+        return true unless @field
+
+        sunspot = Sunspot::Setup.for(@klass)
+        sunspot_field = (sunspot.all_text_fields + sunspot.fields).find {|field| field.name == @field}
+
+        return false unless sunspot_field
         field.attrs[:name] == sunspot_field.indexed_name.to_sym
       end
   end
 
-  def have_indexed_field(klass_or_object, field)
-    HaveIndexedField.new(klass_or_object, field)
+  def have_been_indexed()
+    HaveBeenIndexed.new
   end
 
 end

--- a/lib/sunspot_matchers/sunspot_session_spy.rb
+++ b/lib/sunspot_matchers/sunspot_session_spy.rb
@@ -16,6 +16,7 @@ module SunspotMatchers
     attr_reader :current_search_class
 
     attr_accessor :searches
+    attr_accessor :indexed
 
     def initialize(original_session)
       # Support Sunspot random field in test -- Sunspot originally generate a random number for the field
@@ -26,6 +27,7 @@ module SunspotMatchers
         end
       end
 
+      @indexed = []
       @searches = []
       @original_session = original_session
       @config = Sunspot::Configuration.build
@@ -36,9 +38,20 @@ module SunspotMatchers
     end
 
     def index(*objects)
+      objects.flatten!
+      @indexer ||= Sunspot::Indexer.new(nil)
+      results = objects.map do |object|
+        Sunspot::Util.Array(object).map { |m| @indexer.prepare(m) }
+      end
+      results.each do |doc|
+        doc.each do |d|
+          @indexed << d
+        end
+      end
     end
 
     def index!(*objects)
+      index(objects)
     end
 
     def remove(*objects)

--- a/spec/sunspot_matchers_spec.rb
+++ b/spec/sunspot_matchers_spec.rb
@@ -805,7 +805,7 @@ describe "Sunspot Matchers" do
 
   describe "have_searchable_field" do
     it "works with instances as well as classes" do
-      expect(Post).to have_searchable_field(:body)
+      expect(Post.new).to have_searchable_field(:body)
     end
 
     it "succeeds if the model has the given field" do

--- a/spec/sunspot_matchers_spec.rb
+++ b/spec/sunspot_matchers_spec.rb
@@ -844,7 +844,7 @@ describe "Sunspot Matchers" do
     end
   end
 
-  describe "have_indexed_field" do
+  describe "have_been_indexed" do
     let(:post) {
       post = PersistentPost.new
       post.name = "foo"
@@ -854,28 +854,36 @@ describe "Sunspot Matchers" do
     before(:each) do
       Sunspot.session.index(post)
     end
-    it "works with instances as well as classes" do
-      expect(Sunspot.session).to have_indexed_field(post, :name)
+    it "works with instances" do
+      expect(post).to have_been_indexed
     end
 
-    it "succeeds if the model has been indexed with the given field" do
-      expect(Sunspot.session).to have_indexed_field(PersistentPost, :name)
+    it "works with classes" do
+      expect(PersistentPost).to have_been_indexed
+    end
+
+    it "differentiates between classes" do
+      expect(Post).not_to have_been_indexed
     end
 
     it "succeeds if the model has been indexed with the given field and value" do
-      expect(Sunspot.session).to have_indexed_field(PersistentPost, :name).with("foo")
+      expect(post).to have_been_indexed.with_field(:name, "foo")
+    end
+
+    it "succeeds if the model has been indexed with the given field and the value is any_param" do
+      expect(post).to have_been_indexed.with_field(:name, any_param)
     end
 
     it "fails if the model does not have the given field" do
-      expect(Sunspot.session).not_to have_indexed_field(PersistentPost, :potatoe)
+      expect(post).not_to have_been_indexed.with_field(:potato, "foo")
     end
 
     it "fails if the model was not indexed with the given field" do
-      expect(Sunspot.session).not_to have_indexed_field(PersistentPost, :author_name)
+      expect(post).not_to have_been_indexed.with_field(:author_name, "foo")
     end
 
     it "fails if the model was not indexed with the given field and value" do
-      expect(Sunspot.session).not_to have_indexed_field(PersistentPost, :name).with("bar")
+      expect(post).not_to have_been_indexed.with_field(:name, "bar")
     end
 
     it "fails if this specific instance of the model was not indexed with the given field" do
@@ -883,7 +891,7 @@ describe "Sunspot Matchers" do
       second_post.id = 2
       Sunspot.session.index(second_post)
 
-      expect(Sunspot.session).not_to have_indexed_field(second_post, :name)
+      expect(second_post).not_to have_been_indexed.with_field(:name, "foo")
     end
   end
 end

--- a/sunspot_matchers.gemspec
+++ b/sunspot_matchers.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rspec", "~> 2.0"
-  s.add_development_dependency "sunspot", "~> 2.1.1"
+  #s.add_development_dependency "sunspot", "~> 2.1.1"
   s.add_development_dependency "rake"
 
   s.files        = `git ls-files`.split("\n")


### PR DESCRIPTION
Add have_indexed_field matcher functionality. Documentation on the readme. 

I did not touch the version.

This depends on a modification to sunspot (which I don't like, but I'm not sure of a better way). The `prepare` method on the Indexer needs to be moved out of private. This way the SessionSpy can also make use of it without duplicating code.