### PR TITLE
One-Liner Descriptions

### DIFF
--- a/lib/sunspot_matchers/matchers.rb
+++ b/lib/sunspot_matchers/matchers.rb
@@ -313,6 +313,10 @@ module SunspotMatchers
     def failure_message_when_negated
       "expected search class: #{search_types.join(' and ')} NOT to match expected class: #{@expected_class}"
     end
+
+    def description
+      "be a search for #{@expected_class}"
+    end
   end
 
   def be_a_search_for(expected_class)

--- a/lib/sunspot_matchers/matchers.rb
+++ b/lib/sunspot_matchers/matchers.rb
@@ -332,7 +332,7 @@ module SunspotMatchers
     end
 
     def description
-      "should have searchable field #{@field}"
+      "have searchable field '#{@field}'"
     end
 
     def failure_message

--- a/spec/sunspot_matchers_spec.rb
+++ b/spec/sunspot_matchers_spec.rb
@@ -771,6 +771,12 @@ describe "Sunspot Matchers" do
       end
     end
 
+    it "provides a description" do
+      expected_class = Post
+      description = "be a search for #{expected_class}"
+      expect(be_a_search_for(expected_class).description).to eq description
+    end
+
     it "succeeds if the model is correct" do
       expect(Sunspot.session).to be_a_search_for(Post)
     end

--- a/spec/sunspot_matchers_spec.rb
+++ b/spec/sunspot_matchers_spec.rb
@@ -803,6 +803,12 @@ describe "Sunspot Matchers" do
   end
 
   describe "have_searchable_field" do
+    it "provides a description" do
+      field_name = :author_name
+      description = "have searchable field '#{field_name}'"
+      expect(have_searchable_field(field_name).description).to eq description
+    end
+
     it "works with instances as well as classes" do
       expect(Post).to have_searchable_field(:body)
     end

--- a/spec/sunspot_matchers_spec.rb
+++ b/spec/sunspot_matchers_spec.rb
@@ -762,7 +762,6 @@ describe "Sunspot Matchers" do
         expect(Sunspot.session).to_not have_search_params(:group, :author_name)
       end
     end
-
   end
 
   describe "be_a_search_for" do


### PR DESCRIPTION
**Problem**
Previously, when `be_a_search_for` and `have_searchable_field` were used in one-liners...
``` ruby
require 'sunspot'
require 'sunspot_matchers'
require 'rspec'

class Post; end
class Blog; end

Sunspot.setup(Post) { text :body }

describe "One-Liner Expectations" do
  include SunspotMatchers

  before { Sunspot.session = SunspotMatchers::SunspotSessionSpy.new(Sunspot.session) }

  describe "be_a_search_for" do
    before { Sunspot.search(Post) { keywords 'great pizza' } }
    subject { Sunspot.session }
    it { should be_a_search_for Post }
    it { should_not be_a_search_for Blog }
  end

  describe "have_searchable_field" do
    subject { Post }
    it { should have_searchable_field :body }
    it { should_not have_searchable_field :title }
  end
end
```
...the output was:
```
$ rspec spec/one_liner_spec.rb -fd

One-Liner Expectations
  be_a_search_for
    should When you call a matcher in an example without a String, like this:

specify { expect(object).to matcher }

or this:

it { is_expected.to matcher }

RSpec expects the matcher to have a #description method. You should either
add a String to the example this matcher is being used in, or give it a
description method. Then you won't have to suffer this lengthy warning again.
    should not When you call a matcher in an example without a String, like this:

specify { expect(object).to matcher }

or this:

it { is_expected.to matcher }

RSpec expects the matcher to have a #description method. You should either
add a String to the example this matcher is being used in, or give it a
description method. Then you won't have to suffer this lengthy warning again.
  have_searchable_field
    should should have searchable field body
    should not should have searchable field title

Finished in 0.00305 seconds (files took 0.5246 seconds to load)
4 examples, 0 failures
```

**Solution**
`BeASearchFor#description` is defined and `HaveSearchableField#description` is updated:
```
$ rspec spec/one_liner_spec.rb -fd

One-Liner Expectations
  be_a_search_for
    should be a search for Post
    should not be a search for Blog
  have_searchable_field
    should have searchable field 'body'
    should not have searchable field 'title'

Finished in 0.00196 seconds (files took 0.50971 seconds to load)
4 examples, 0 failures
```
Hope this helps! :smile_cat: 