### PR TITLE
Add a new matcher for testing the existence of dynamic fields on searchable objects.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -66,6 +66,18 @@ You can also use the shorthand syntax:
       it { should have_searchable_field(:name) }
     end
 
+## have_dynamic_field
+
+If you want to verify that a model has a dynamic searchable field, you can use this matcher:
+
+`Post.should have_dynamic_field(:commenter_read)`
+
+You can also use the shorthand syntax:
+
+    describe User do
+      it { should have_dynamic_field(:commenter_read) }
+    end
+
 ## have_search_params
 
 This is where the bulk of the functionality lies.  There are seven types of search matches you can perform: `keywords` or `fulltext`,

--- a/spec/have_dynamic_field_matcher_spec.rb
+++ b/spec/have_dynamic_field_matcher_spec.rb
@@ -1,0 +1,30 @@
+require 'sunspot'
+require 'sunspot_matchers'
+require 'rspec'
+
+describe SunspotMatchers::HaveDynamicField do
+  let(:matcher) do
+    described_class.new(:field).tap do |matcher|
+      matcher.matches? klass
+    end
+  end
+
+  context "when a class has no searchable fields" do
+    let(:klass) { NotALotGoingOn = Class.new }
+
+    it "gives Sunspot configuration error" do
+      expect(matcher.failure_message).to match(/Sunspot was not configured/)
+    end
+  end
+
+  context "when a class has an unexpected searchable field" do
+    let(:klass) { IndexedWithWrongThings = Class.new }
+    before do
+      Sunspot.setup(klass) { text :parachute }
+    end
+
+    it "does not have an error" do
+      expect(matcher.failure_message).to be_nil
+    end
+  end
+end

--- a/spec/sunspot_matchers_spec.rb
+++ b/spec/sunspot_matchers_spec.rb
@@ -18,6 +18,7 @@ Sunspot.setup(Post) do
   integer :popularity
   time :published_at
   float :average_rating
+  dynamic_boolean(:commenter_read)
 end
 
 Sunspot.setup(Blog) do
@@ -815,8 +816,9 @@ describe "Sunspot Matchers" do
       expect(have_searchable_field(field_name).description).to eq description
     end
 
-    it "works with instances as well as classes" do
-      expect(Post).to have_searchable_field(:body)
+    context "when given an instance" do
+      subject {Post.new}
+      it { is_expected.to have_searchable_field(:body) }
     end
 
     it "succeeds if the model has the given field" do
@@ -831,6 +833,31 @@ describe "Sunspot Matchers" do
 
     it "fails if the model does not have any searchable fields" do
       expect(Person).to_not have_searchable_field(:name)
+    end
+  end
+
+  describe "have_dynamic_field" do
+    it "provides a description" do
+      field_name = :commenter_read
+      description = "have dynamic searchable field '#{field_name}'"
+      expect(have_dynamic_field(field_name).description).to eq description
+    end
+
+    context "when given an instance" do
+      subject {Post.new}
+      it { is_expected.to have_dynamic_field(:commenter_read) }
+    end
+
+    it "succeeds if the model has the given field" do
+      expect(Post).to have_dynamic_field(:commenter_read)
+    end
+
+    it "fails if the model does not have the given field" do
+      expect(Post).to_not have_dynamic_field(:potato)
+    end
+
+    it "fails if the model does not have any dynamic fields" do
+      expect(Person).to_not have_dynamic_field(:name)
     end
   end
 end


### PR DESCRIPTION
This could also be handled by modifying the existing HaveSearchableField to simply look at all field factories on the configured object, but I didn't want to change existing behavior too much.  
```ruby
@sunspot.all_field_factories.collect(&:name).include?(@field)
```
Let me know if this would be preferable and I'll update the pull request.

This also fixes an old test that was supposed to be verifying that the have_searchable_field matcher worked on both instances and objects, but was simply testing the object behavior.  Test was broken when being upgrdaed to rspec 'expect' syntax