### PR TITLE
Adding optional param to commit_if_dirty that sunspot added in v2.2.0

### DIFF
--- a/lib/sunspot_matchers/sunspot_session_spy.rb
+++ b/lib/sunspot_matchers/sunspot_session_spy.rb
@@ -67,7 +67,7 @@ module SunspotMatchers
       false
     end
 
-    def commit_if_dirty
+    def commit_if_dirty(soft_delete = false)
     end
 
     def commit_if_delete_dirty


### PR DESCRIPTION
After upgrading my Rails app to 4.2 and Sunspot to 2.2.0 my specs started failing with:
```
     ArgumentError:
       wrong number of arguments (1 for 0)
     # /.../sunspot_matchers-2.2.0.0/lib/sunspot_matchers/sunspot_session_spy.rb:70:in `commit_if_dirty'
     # /.../sunspot/lib/sunspot.rb:520:in `commit_if_dirty'
     # /.../sunspot_rails/lib/sunspot/rails/request_lifecycle.rb:26:in `block (2 levels) in included'
```
It looks like Sunspot now calls session.commit_if_dirty with a boolean param
https://github.com/sunspot/sunspot/commit/a6e38738448f674c8530004efd388bf737996c3d#diff-59fbdad8c1e59b79f7cce4e67691d803R219

I added the param, but I didn't know how to add a test for this or even if one is needed.