### PR TITLE
Allows HaveSearchParams expectation to accept nil

### DIFF
--- a/lib/sunspot_matchers/matchers.rb
+++ b/lib/sunspot_matchers/matchers.rb
@@ -127,7 +127,7 @@ module SunspotMatchers
   class HaveSearchParams
     def initialize(method, *args, &block)
       @method = method
-      @args = [*args, block].compact
+      @args = (block.nil? ? args : [*args, block])
     end
 
     def matches?(actual)

--- a/lib/sunspot_matchers/test_helper.rb
+++ b/lib/sunspot_matchers/test_helper.rb
@@ -9,7 +9,7 @@ module SunspotMatchers
     def initialize(session, method, *args, &block)
       @session = session
       @method = method
-      @args = [*args, block].compact
+      @args = (block.nil? ? args : [*args, block])
     end
 
     def get_matcher
@@ -33,7 +33,7 @@ module SunspotMatchers
     end
   end
 
-  
+
   class BeASearchForSession
     def initialize(session, expected_class)
       @session = session
@@ -74,7 +74,7 @@ module SunspotMatchers
       matcher = HaveSearchParamsForSession.new(session, method, *args, &block).get_matcher
       assert !matcher.match?, matcher.unexpected_match_error_message
     end
-    
+
     def assert_is_search_for(session, expected_class)
       matcher = BeASearchForSession.new(session, expected_class)
       assert matcher.match?, matcher.failure_message_for_should

--- a/spec/sunspot_matchers_spec.rb
+++ b/spec/sunspot_matchers_spec.rb
@@ -52,6 +52,22 @@ describe "Sunspot Matchers" do
       expect(Sunspot.session.searches.last).to have_search_params(:keywords, 'bad pizza')
     end
 
+    context 'when the search arg is nil' do
+      before do
+        Sunspot.search(Post) { with(:published_at, Time.now) }
+      end
+
+      it 'respects expectations on nil parameters' do
+        expect {
+          expect(Sunspot.session.searches.first).to have_search_params(:with, :published_at, nil)
+        }.to raise_error RSpec::Expectations::ExpectationNotMetError
+      end
+
+      it 'allows negated expectation on nil' do
+        expect(Sunspot.session.searches.last).not_to have_search_params(:with, :published_at, nil)
+      end
+    end
+
     describe "keyword/fulltext matcher" do
       it "matches if search matches" do
         Sunspot.search(Post) do

--- a/test/sunspot_matchers_test.rb
+++ b/test/sunspot_matchers_test.rb
@@ -47,7 +47,21 @@ class SunspotMatchersTest < MiniTest::Unit::TestCase
     end
     assert_has_search_params Sunspot.session, :keywords, 'great pizza'
   end
-  
+
+  def test_respects_expectation_on_nil
+    Sunspot.search(Post) do
+      with(:published_at, Time.now)
+    end
+    assert_raises(MiniTest::Assertion) { assert_has_search_params(Sunspot.session, :with, :published_at, nil) }
+  end
+
+  def test_respects_negated_expectation_on_nil
+    Sunspot.search(Post) do
+      with(:published_at, Time.now)
+    end
+    assert_has_no_search_params Sunspot.session, :with, :published_at, nil
+  end
+
   def test_match_keywords
     Sunspot.search(Post) do
       keywords 'great pizza'
@@ -699,7 +713,7 @@ class SunspotMatchersTest < MiniTest::Unit::TestCase
     assert_is_search_for Sunspot.session, Blog
     assert_is_not_search_for Sunspot.session, Person
   end
- 
+
   def test_be_a_search_for_multiple_searches
     Sunspot.search(Post) { keywords 'great pizza' }
     Sunspot.search(Blog) { keywords 'bad pizza' }


### PR DESCRIPTION
Before, `have_search_params(:with, :published_at, nil)` would strip out the `nil` and return false positives. Now, expectations with `nil` will ensure the correct query is formed.

Here's a more verbose example of the problem and the fix:
```ruby
class Post < ActiveRecord::Base
  searchable { time :published_at }
end

# search for unpublished posts
Post.search { with(:published_at, nil) }
expect(Sunspot.session).to have_search_params(:with, :published_at, nil)
#=> PASSES

# but if the search is incorrect...
# BEFORE
Post.search { with(:published_at, Time.now) }
expect(Sunspot.session).to have_search_params(:with, :published_at, nil)
#=> STILL PASSES

# AFTER
Post.search { with(:published_at, Time.now) }
expect(Sunspot.session).to have_search_params(:with, :published_at, nil)
#=> FAILS AS EXPECTED
```